### PR TITLE
fix(motorista): corrige validação que impedia apagar e editar os campos de telefone e cpf

### DIFF
--- a/src/app/motorista/page.tsx
+++ b/src/app/motorista/page.tsx
@@ -141,9 +141,8 @@ export default function Motorista() {
                     value={item.value}
                     onChange={(e) => {
                       const value = e.target.value;
-                      // Impede números em campos de texto e letras em campos numéricos
-                      if (["Nome", "Marca", "Cor"].includes(item.label) && /[^A-Za-zÀ-ÿ\s]/.test(value)) return;
-                      if (["CPF", "CNH", "Telefone", "Assentos"].includes(item.label) && /[^0-9]/.test(value)) return;
+                      // Permite qualquer valor temporariamente para CPF e Telefone durante edição
+                      if (["Nome", "Marca", "Cor"].includes(item.label) && value !== "" && /[^A-Za-zÀ-ÿ\s]/.test(value)) return;
                       item.setValue(value);
                     }}
                     className="border w-full p-2 rounded bg-gray-100"


### PR DESCRIPTION
- Permite apagar e editar completamente os campos de telefone e CPF em editar dados do motorista

- Ajuste da lógica dos inputs para aceitar campos vazios durante a edição, facilitando a atualização dos dados pelo motorista