### PR TITLE
chore(git): atualizar .gitignore, remover .vscode e package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,22 @@ out/
 .classpath
 .settings/
 
+# NetBeans
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+/build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+# Spring Tools Suite
+.apt_generated
+.factorypath
+.springBeans
+.sts4-cache
+
 # VSCode
 .vscode/
 .history/
@@ -37,25 +53,46 @@ out/
 # =========================
 # Backend - Java / Spring Boot
 # =========================
-backend/target/
-backend/.mvn/
-backend/mvnw
-backend/mvnw.cmd
-backend/logs/
+target/
+!.mvn/wrapper/maven-wrapper.jar
+.mvn/
+mvnw
+mvnw.cmd
+logs/
 *.log
 
 # =========================
-# Frontend - Node/React/Vue/Angular
+# Frontend - Node/React/Vue/Next.js
 # =========================
-frontend/node_modules/
-frontend/dist/
-frontend/.next/
-frontend/.nuxt/
-frontend/out/
+node_modules/
+dist/
+.next/
+.nuxt/
+out/
+build/
+
+# Coverage / test
+coverage/
+
+# Debug logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+
+# Package managers
+yarn.lock
+package-lock.json
+pnpm-lock.yaml
+
+# Yarn Plug'n'Play
+.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # =========================
 # Docker
@@ -63,12 +100,18 @@ pnpm-debug.log*
 docker-compose.override.yml
 *.env
 .env.*
+.env.local*
 *.bak
+
+# Vercel (Next.js hosting)
+.vercel
+
+# Sentry Config
+.env.sentry-build-plugin
 
 # =========================
 # Banco de dados / SQL
 # =========================
-# (mantém os scripts versionados, só ignora dumps grandes)
 *.sql.gz
 *.dump
 *.bak
@@ -81,10 +124,12 @@ docker-compose.override.yml
 *.swp
 *.swo
 *.lock
+*.tsbuildinfo
+*.pem
 
 # =========================
 # Arquivos específicos do projeto
 # =========================
 Help.md
+HELP.md
 next-env.d.ts
-package-lock.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.compile.nullAnalysis.mode": "disabled"
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "pi-borasio",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Removi a pasta .vscode e o arquivo package-lock.json do versionamento do Git, mas deixei eles no meu projeto.  
Agora como já estão no .gitignore, o Git não vai mais rastrear esses arquivos e eles não aparecem mais no git status.
mas não sei se isso vai ser só no meu computador ou no projeto inteiro. por isso vou observar com atenção.


Consolidei e organizei as regras de ignore  .gitignore na raiz do projeto.
Agora o arquivo cobre:
- Sistema operacional (Windows, macOS, Linux)
- IDEs e editores (IntelliJ, Eclipse, VSCode, NetBeans, STS)
- Backend (Spring Boot/Java)
- Frontend (Node.js, React, Next.js, Vue, Angular)
- Docker e arquivos .env
- Banco de dados e dumps SQL
- Arquivos de testes, coverage e builds
- Arquivos específicos do projeto (Help.md, next-env.d.ts, etc.)

Esse ajuste elimina duplicações e garante que os principais artefatos gerados
no desenvolvimento não sejam versionados.
