### PR TITLE
feat(auth): implementa autenticação JWT

### DIFF
--- a/backend/src/main/java/com/borasio_back/backend/config/JwtUtil.java
+++ b/backend/src/main/java/com/borasio_back/backend/config/JwtUtil.java
@@ -1,5 +1,25 @@
 package com.borasio_back.backend.config;
 
+import com.borasio_back.backend.model.entity.Usuario;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
 public class JwtUtil {
-    
+	private final String jwtSecret = "segredoSuperSecreto"; // Troque para variável de ambiente em produção
+	private final long jwtExpirationMs = 86400000; // 1 dia
+
+	public String generateToken(Usuario usuario) {
+		return Jwts.builder()
+				.setSubject(usuario.getEmail())
+				.claim("id", usuario.getId())
+				.claim("role", usuario.getTipo())
+				.setIssuedAt(new Date())
+				.setExpiration(new Date(System.currentTimeMillis() + jwtExpirationMs))
+				.signWith(SignatureAlgorithm.HS512, jwtSecret)
+				.compact();
+	}
 }

--- a/backend/src/main/java/com/borasio_back/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/borasio_back/backend/controller/AuthController.java
@@ -1,5 +1,23 @@
 package com.borasio_back.backend.controller;
 
+import com.borasio_back.backend.dto.AuthRequest;
+import com.borasio_back.backend.dto.AuthResponse;
+import com.borasio_back.backend.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
 public class AuthController {
-    
+	private final AuthService authService;
+
+	public AuthController(AuthService authService) {
+		this.authService = authService;
+	}
+
+	@PostMapping("/login")
+	public ResponseEntity<AuthResponse> login(@RequestBody AuthRequest request) {
+		AuthResponse response = authService.authenticate(request);
+		return ResponseEntity.ok(response);
+	}
 }

--- a/backend/src/main/java/com/borasio_back/backend/service/AuthService.java
+++ b/backend/src/main/java/com/borasio_back/backend/service/AuthService.java
@@ -1,5 +1,42 @@
 package com.borasio_back.backend.service;
 
-public class AuthService {
+import com.borasio_back.backend.dto.AuthRequest;
+import com.borasio_back.backend.dto.AuthResponse;
+import com.borasio_back.backend.model.entity.Usuario;
+import com.borasio_back.backend.repository.UsuarioRepository;
+import com.borasio_back.backend.config.JwtUtil;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
 
+@Service
+public class AuthService {
+	private final AuthenticationManager authenticationManager;
+	private final UsuarioRepository usuarioRepository;
+	private final JwtUtil jwtUtil;
+
+	public AuthService(AuthenticationManager authenticationManager, UsuarioRepository usuarioRepository, JwtUtil jwtUtil) {
+		this.authenticationManager = authenticationManager;
+		this.usuarioRepository = usuarioRepository;
+		this.jwtUtil = jwtUtil;
+	}
+
+	public AuthResponse authenticate(AuthRequest request) {
+		Authentication authentication = authenticationManager.authenticate(
+				new UsernamePasswordAuthenticationToken(request.getEmail(), request.getSenha())
+		);
+
+		Usuario usuario = usuarioRepository.findByEmail(request.getEmail())
+				.orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado"));
+
+		String token = jwtUtil.generateToken(usuario);
+		return new AuthResponse(
+			token,
+			usuario.getId(),
+			usuario.getEmail(),
+			usuario.getTipo()
+		);
+	}
 }


### PR DESCRIPTION
Adiciona endpoint /auth/login para autenticação de usuários utilizando JWT. 
Implementa AuthService para validar credenciais e gerar token JWT, e ajusta AuthResponse e JwtUtil para suportar o fluxo de autenticação.

Implementado o AuthController com endpoint /auth/login que recebe email e senha, chama o AuthService e retorna um token JWT e dados do usuário.
Implementado o AuthService que autentica o usuário usando o AuthenticationManager, busca o usuário no banco e gera o token JWT.
Criado método generateToken(Usuario usuario) em JwtUtil para gerar o token JWT com claims do usuário.
Ajustado o DTO AuthResponse para retornar token, id, email e role do usuário autenticado.