### PR TITLE
fix(reset-password): wrap ResetarSenhaForm

### DIFF
--- a/frontend/src/app/resetar-senha/page.tsx
+++ b/frontend/src/app/resetar-senha/page.tsx
@@ -1,9 +1,13 @@
+
+import { Suspense } from 'react';
 import ResetarSenhaForm from '../components/ResetarSenhaForm';
 
 export default function ResetarSenhaPage() {
   return (
     <main className="resetar-senha-container">
-      <ResetarSenhaForm />
+      <Suspense fallback={<div>Carregando formulário...</div>}>
+        <ResetarSenhaForm />
+      </Suspense>
     </main>
   );
 }


### PR DESCRIPTION
O erro ocorreu porque o hook useSearchParams do Next.js requer que o componente esteja dentro de um <Suspense> boundary em Client Components. O componente ResetarSenhaForm foi envolvido por <Suspense> no arquivo page.tsx, corrigindo o erro de build e permitindo o uso correto do hook.
